### PR TITLE
Added actual restart

### DIFF
--- a/source/sync.sh
+++ b/source/sync.sh
@@ -75,6 +75,8 @@ function restart_pi_timolo ()
     echo "------------------------------------------"
     echo "START   - restart_pi_timolo"
     echo "INFO    - Starting pi-timolo"
+    $PROG_DIR/pi-timolo.sh stop
+    sleep 5
     $PROG_DIR/pi-timolo.sh start
     sleep 5
     if [ -z "$(pgrep -f pi-timolo.py)" ] ; then


### PR DESCRIPTION
Currently if the config is changed and pi-timolo is running there is no real restart. 
I added a stop command before the start command to make it a real restart.
This is necessary, because python creates a .pyc file for the config and even if config.py is changed no changes take place until a actual restart has happened.