### PR TITLE
Added a Wipe function to sync.sh

### DIFF
--- a/source/sync.sh
+++ b/source/sync.sh
@@ -342,7 +342,7 @@ function do_wipe_sync ()
             echo "          to $PROG_DIR/$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE  (local)"
             /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
             echo "DELETE  - $SYNC_DIR  (local)"
-            rm $SYNC_DIR/*jpg
+            drive list -match-mime jpg $SYNC_DIR | cut -c2- |  xargs echo rm -f | sh
             echo "SUCCESS - $SYNC_DIR  is now empty"
             echo "------------------------------------------"
             echo "GDRIVE  - Sync push Local /$REMOTE_WIPE_DIR Files to Local to $REMOTE_WIPE_DIR"

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -345,7 +345,7 @@ function do_wipe_sync ()
             /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
             echo "DELETE  - $SYNC_DIR  (local)"
             if $REMOTE_WIPE_SAFE ; then 
-                drive list -match-mime jpg $SYNC_DIR | cut -c2- | xargs -n 10 echo rm  | sh
+                drive list -match-mime jpg $SYNC_DIR | cut -c2- | xargs -n 10 echo rm -f | sh
             else
                 rm $SYNC_DIR/*jpg
             fi    

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -344,7 +344,7 @@ function do_wipe_sync ()
             echo "          to $PROG_DIR/$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE  (local)"
             /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
             echo "DELETE  - $SYNC_DIR  (local)"
-            if $REMOTE_WIPE_SAVE ; then 
+            if $REMOTE_WIPE_SAFE ; then 
                 drive list -match-mime jpg $SYNC_DIR | cut -c2- | xargs -n 10 echo rm  | sh
             else
                 rm $SYNC_DIR/*jpg

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -345,7 +345,7 @@ function do_wipe_sync ()
             /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
             echo "DELETE  - $SYNC_DIR  (local)"
             if $REMOTE_WIPE_SAFE ; then 
-                drive list -match-mime jpg $SYNC_DIR | cut -c2- | xargs -n 10 echo rm -f | sh
+                /usr/local/bin/gdrive list -match-mime jpg $SYNC_DIR | cut -c2- | xargs -n 10 echo rm -f | sh
             else
                 rm $SYNC_DIR/*jpg
             fi    

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -45,6 +45,13 @@ REMOTE_CONFIG_DIR='sync_config_cam1'   # Remote Config Folder on google drive (W
 REMOTE_CONFIG_FILE='config.py'         # Name of new pi-timolo config file on google drive
 LOCAL_CONFIG_FILE='config.py'          # pi-timolo configuration variables file (default)
 
+# ------------------ Remote Sync Wipe Settings -------------------
+# Remote Wipe will erase all Files in the syc folder ater syncing 
+# as long as a file wipe.me is located in the remote google drive
+REMOTE_WIPE_ON=false                   # true - Check for wipe.me file and wipe sync folder, false - Ignore Checking
+REMOTE_WIPE_DIR='sync_config_cam1'     # Remote Wipe Folder on google drive (Will be Created if Does Not Exist)
+REMOTE_WIPE_FILE='wipe.me'             # Name of the wipe file on google drive
+
 # -------------------- Watch App Settings --------------------------
 WATCH_APP_ON=false           # false - off  true - Check if app is running and restart or reboot
 WATCH_APP='pi-timolo.py'     # App filename to monitor for Run Status
@@ -61,6 +68,10 @@ echo "REMOTE_CONFIG_ON    =" $REMOTE_CONFIG_ON
 echo "REMOTE_CONFIG_DIR   =" $REMOTE_CONFIG_DIR
 echo "REMOTE_CONFIG_FILE  =" $REMOTE_CONFIG_FILE
 echo "LOCAL_CONFIG_FILE   =" $LOCAL_CONFIG_FILE
+echo ""
+echo "REMOTE_WIPE_ON    =" $REMOTE_WIPE_ON
+echo "REMOTE_WIPE_DIR   =" $REMOTE_WIPE_DIR
+echo "REMOTE_WIPE_FILE  =" $REMOTE_WIPE_FILE
 echo ""
 echo "WATCH_APP_ON        =" $WATCH_APP_ON
 echo "WATCH_APP           =" $WATCH_APP
@@ -230,7 +241,8 @@ function do_config_sync ()
             mkdir $PROG_DIR/$REMOTE_CONFIG_DIR
             cp $PROG_DIR/$LOCAL_CONFIG_FILE $PROG_DIR/$REMOTE_CONFIG_DIR/$REMOTE_CONFIG_FILE.orig
 
-            echo "GDRIVE  - Sync push Local /$LOCAL_CONFIG_DIR Files to Local to $REMOTE_CONFIG_DIR"
+            echo "GDRIVE  - Sync push Local /
+            Files to Local to $REMOTE_CONFIG_DIR"
             /usr/local/bin/gdrive push -no-prompt -ignore-conflict $REMOTE_CONFIG_DIR/$REMOTE_CONFIG_FILE.orig
        fi
     fi
@@ -284,7 +296,66 @@ function do_config_sync ()
         fi
     fi
 }
+# ------------------------------------------------------
+function do_wipe_sync ()
+{
+    # function to wipe local copy of synced files
+    # remote files will not be effected 
+    # regular wipes speed up the sync process
+    
+    echo "------------------------------------------"
+    echo "START   - do_wipe_sync - Remote Wipe Checks"
+    echo "INFO    - Look for new wipe file on google drive"
+    echo "          at $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE (remote)"
 
+    # check if folder exists locally and if not create one
+    if [ ! -d $PROG_DIR/$REMOTE_WIPE_DIR ] ; then
+        echo "STATUS  - Creating Remote Folder /$REMOTE_WIPE_DIR"
+        echo "------------------------------------------"
+        /usr/local/bin/gdrive new --folder $REMOTE_WIPE_DIR
+        /usr/local/bin/gdrive file-id $REMOTE_WIPE_DIR
+        if [ $? -ne 0 ] ; then
+            echo "------------------------------------------"
+            echo "ERROR   -  Could Not Create Remote $REMOTE_WIPE_DIR"
+            echo "          1 Lost Internet Connection"
+            echo "          2 Some Other Reason."
+        else
+            echo "STATUS - mkdir $REMOTE_WIPE_DIR  (local)"
+            mkdir $PROG_DIR/$REMOTE_WIPE_DIR
+       fi
+    fi
+
+    echo "GDRIVE  - Check Remote Wipe File Exists - /$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE"
+    /usr/local/bin/gdrive pull -no-prompt -ignore-conflict $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE
+    if [ $? -ne 0 ] ; then   # Check if gdrive exited successfully
+        echo "------------------------------------------"
+        echo "WARN    - Remote Wipe Check Failed"
+        echo "          See gdrive message above for Details."
+        echo "          Possible Cause"
+        echo "          1 Remote File Not Found /$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE"
+        echo "          2 Lost Internet Connection"
+        echo "          3 Some Other Reason."
+    else
+        # Download successful start update of pi-timolo config.py
+        if [ -e $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE ] ; then
+            echo "STATUS  - Successfully Downloaded $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE  (remote)"
+            echo "          to $PROG_DIR/$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE  (local)"
+            /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
+            echo "DELETE  - $SYNC_DIR  (local)"
+            rm -r $SYNC_DIR
+            echo "CREATE - $SYNC_DIR  (local)"
+            mkdir $SYNC_DIR
+            echo "SUCCESS - $SYNC_DIR  is now empty"
+            echo "------------------------------------------"
+            echo "GDRIVE  - Sync push Local /$LOCAL_WIPE_DIR Files to Local to $REMOTE_WIPE_DIR"
+            /usr/local/bin/gdrive push -no-prompt -ignore-conflict $REMOTE_WIPE_DIR
+            echo "TRASH   - Empty gdrive trash  (local)"
+            /usr/local/bin/gdrive emptytrash -no-prompt
+        else
+            echo "GDRIVE  - $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE Not Found (local)"
+        fi
+    fi
+}
 # ------------------------------------------------------
 function watch_app ()
 {
@@ -317,6 +388,10 @@ fi
 
 if $REMOTE_CONFIG_ON ; then  # Check if remote configuration feature is on
     do_config_sync
+fi
+
+if $REMOTE_WIPE_ON ; then  # Check if remote configuration feature is on
+    do_wipe_sync
 fi
 
 if $WATCH_APP_ON ; then # check if watch app feature is on

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -342,9 +342,7 @@ function do_wipe_sync ()
             echo "          to $PROG_DIR/$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE  (local)"
             /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
             echo "DELETE  - $SYNC_DIR  (local)"
-            rm -r $SYNC_DIR
-            echo "CREATE - $SYNC_DIR  (local)"
-            mkdir $SYNC_DIR
+            rm $SYNC_DIR/*jpg
             echo "SUCCESS - $SYNC_DIR  is now empty"
             echo "------------------------------------------"
             echo "GDRIVE  - Sync push Local /$REMOTE_WIPE_DIR Files to Local to $REMOTE_WIPE_DIR"

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -388,7 +388,7 @@ if $REMOTE_CONFIG_ON ; then  # Check if remote configuration feature is on
     do_config_sync
 fi
 
-if $REMOTE_WIPE_ON ; then  # Check if remote configuration feature is on
+if $REMOTE_WIPE_ON ; then  # Check if remote wipe feature is on
     do_wipe_sync
 fi
 

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -240,7 +240,7 @@ function do_config_sync ()
             echo "STATUS - mkdir $REMOTE_CONFIG_DIR  (local)"
             mkdir $PROG_DIR/$REMOTE_CONFIG_DIR
             cp $PROG_DIR/$LOCAL_CONFIG_FILE $PROG_DIR/$REMOTE_CONFIG_DIR/$REMOTE_CONFIG_FILE.orig
-
+            echo "GDRIVE  - Sync push Local /$REMOTE_CONFIG_DIR Files to Local to $REMOTE_CONFIG_DIR"
             echo "GDRIVE  - Sync push Local /
             Files to Local to $REMOTE_CONFIG_DIR"
             /usr/local/bin/gdrive push -no-prompt -ignore-conflict $REMOTE_CONFIG_DIR/$REMOTE_CONFIG_FILE.orig
@@ -347,7 +347,7 @@ function do_wipe_sync ()
             mkdir $SYNC_DIR
             echo "SUCCESS - $SYNC_DIR  is now empty"
             echo "------------------------------------------"
-            echo "GDRIVE  - Sync push Local /$LOCAL_WIPE_DIR Files to Local to $REMOTE_WIPE_DIR"
+            echo "GDRIVE  - Sync push Local /$REMOTE_WIPE_DIR Files to Local to $REMOTE_WIPE_DIR"
             /usr/local/bin/gdrive push -no-prompt -ignore-conflict $REMOTE_WIPE_DIR
             echo "TRASH   - Empty gdrive trash  (local)"
             /usr/local/bin/gdrive emptytrash -no-prompt

--- a/source/sync.sh
+++ b/source/sync.sh
@@ -51,6 +51,7 @@ LOCAL_CONFIG_FILE='config.py'          # pi-timolo configuration variables file 
 REMOTE_WIPE_ON=false                   # true - Check for wipe.me file and wipe sync folder, false - Ignore Checking
 REMOTE_WIPE_DIR='sync_config_cam1'     # Remote Wipe Folder on google drive (Will be Created if Does Not Exist)
 REMOTE_WIPE_FILE='wipe.me'             # Name of the wipe file on google drive
+REMOTE_WIPE_SAFE=true                  # true - only synced files get deleted but this is slow, false- all jpg files get deleted 
 
 # -------------------- Watch App Settings --------------------------
 WATCH_APP_ON=false           # false - off  true - Check if app is running and restart or reboot
@@ -72,6 +73,7 @@ echo ""
 echo "REMOTE_WIPE_ON    =" $REMOTE_WIPE_ON
 echo "REMOTE_WIPE_DIR   =" $REMOTE_WIPE_DIR
 echo "REMOTE_WIPE_FILE  =" $REMOTE_WIPE_FILE
+echo "REMOTE_WIPE_SAFE  =" $REMOTE_WIPE_SAFE
 echo ""
 echo "WATCH_APP_ON        =" $WATCH_APP_ON
 echo "WATCH_APP           =" $WATCH_APP
@@ -342,7 +344,11 @@ function do_wipe_sync ()
             echo "          to $PROG_DIR/$REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE  (local)"
             /usr/local/bin/gdrive rename -force $REMOTE_WIPE_DIR/$REMOTE_WIPE_FILE $REMOTE_WIPE_FILE.done
             echo "DELETE  - $SYNC_DIR  (local)"
-            drive list -match-mime jpg $SYNC_DIR | cut -c2- |  xargs echo rm -f | sh
+            if $REMOTE_WIPE_SAVE ; then 
+                drive list -match-mime jpg $SYNC_DIR | cut -c2- | xargs -n 10 echo rm  | sh
+            else
+                rm $SYNC_DIR/*jpg
+            fi    
             echo "SUCCESS - $SYNC_DIR  is now empty"
             echo "------------------------------------------"
             echo "GDRIVE  - Sync push Local /$REMOTE_WIPE_DIR Files to Local to $REMOTE_WIPE_DIR"


### PR DESCRIPTION
I noticed syncing becoming really slow at about 400 files. 
So I added a modified remote-config-function to wipe the sync dir if a certain file  exists in the Google drive.
Since the files are already synced when the function is called there should be no dataloss.

This function can be quite handy if your pi is miles away and you don't want the sd card to fill up ;) and it speeds up sync.