### PR TITLE
Fix for DF info

### DIFF
--- a/source/webserver3.py
+++ b/source/webserver3.py
@@ -94,7 +94,7 @@ def df(drive_mnt):
     '''
     try:
         df = subprocess.Popen(["df", "-h", drive_mnt], stdout=subprocess.PIPE)
-        output = df.communicate()[0]
+        output = df.communicate()[0].decode('utf-8')
         device, size, used, available, percent, mountpoint = output.split("\n")[1].split()
         drive_status = ("Drive [ %s ] Mount_Point [ %s ] Space_Used [ %s %s of %s ] Space_Avail [ %s ]" %
                         (device, mountpoint, percent, used, size, available))


### PR DESCRIPTION
Subprocess returns a byte array in python3, and the output is processed as a string - therefore, we need to convert df's output into a string before we work with it.