### PR TITLE
Replace ifconfig with ip

### DIFF
--- a/source/menubox.sh
+++ b/source/menubox.sh
@@ -38,7 +38,7 @@ function init_status ()
      WEB_2="webserver.py in background"
   else
      webserver_pid=$( pgrep -f $DIR/webserver.py )
-     myip=$( ifconfig -a | grep 'inet ' | grep -v 127.0.0 | head -n 1 | tr -s " " | cut -d " " -f 3 )
+     myip=$( ip route get 8.8.8.8 | sed -n '/src/{s/.*src *\([^ ]*\).*/\1/p;q}' )
      myport=$( grep "web_server_port" config.py | cut -d "=" -f 2 | cut -d "#" -f 1 | awk '{$1=$1};1' )
      WEB_1="STOP"
      WEB_2="webserver.py - PID is $webserver_pid http://$myip:$myport"


### PR DESCRIPTION
`ifconfig` was deprecated in favor of `ip` and is no longer shipped by default in the Raspberry Pi OS. `./menubox` will raise a non-fatal error every time I use it because I don't have `ifconfig` installed on my system. This PR replaces `ifconfig` with `ip` as a proposed solution (as opposed to making changes to the installation part).