### PR TITLE
fixes user_motion_code.userMotionCode not running

### DIFF
--- a/source/pi-timolo.py
+++ b/source/pi-timolo.py
@@ -3010,19 +3010,19 @@ def timolo():
                     )
                     logging.info("Next Pano at %s  Waiting ...", next_pano_at)
 
-                if motionFound and motionCode:
-                    # ===========================================
-                    # Put your user code in userMotionCode() function
-                    # In the File user_motion_code.py
-                    # ===========================================
-                    try:
-                        user_motion_code.userMotionCode(filename)
-                        dotCount = showDots(MOTION_DOTS_MAX)
-                    except ValueError:
-                        logging.error(
-                            "Problem running userMotionCode function from File %s",
-                            userMotionFilePath,
-                        )
+            if motionFound and motionCode:
+                # ===========================================
+                # Put your user code in userMotionCode() function
+                # In the File user_motion_code.py
+                # ===========================================
+                try:
+                    user_motion_code.userMotionCode(filename)
+                    dotCount = showDots(MOTION_DOTS_MAX)
+                except ValueError:
+                    logging.error(
+                        "Problem running userMotionCode function from File %s",
+                        userMotionFilePath,
+                    )
             else:
                 # show progress dots when no motion found
                 dotCount = showDots(dotCount)


### PR DESCRIPTION
fixes #130

The indent was off by one level and user_motion_code.userMotionCode would only run if you were using PANO. 

I didn't test every permuation, but with no plugins, default config and uncommenting the prints in userMotionCode, this worked.

```bash
023-05-17 22:30:28 INFO     timolo     Motion Triggered Start(239,9)  End(145,21) trackLen=94/50 px

2023-05-17 22:30:30 INFO     takeNightImage 1280x768  TwilightThresh=92/90  MaxISO=800 uses framerate_range
2023-05-17 22:30:34 INFO     writeTextToImage Added White Text [ 1001  20230517_22:30:34 ]
2023-05-17 22:30:34 INFO     writeTextToImage Saved media/motion/mo-cam1-1001.jpg
2023-05-17 22:30:34 INFO     writeCounter Next Counter=1002 ./data/mo-pi-timolo.dat
2023-05-17 22:30:34 INFO     makeRelSymlink Saved at media/recent/motion/mo-cam1-1001.jpg
2023-05-17 22:30:36 INFO     timolo     Waiting for Next Motion Tracking Event ...
User Code Executing from userMotionCode function
file path is media/motion/mo-cam1-1001.jpg
2023-05-17 22:30:37 INFO     timolo     Track Timer 0.30 sec Exceeded. Reset Track
2023-05-17 22:30:40 INFO     timolo     Track Timer 0.30 sec Exceeded. Reset Track
2023-05-17 22:30:41 INFO     timolo     Track Timer 0.30 sec Exceeded. Reset Track
2023-05-17 22:30:44 INFO     timolo     Track Timer 0.30 sec Exceeded. Reset Track
```